### PR TITLE
Fix line number start info in config template file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,8 @@ This release includes _PasHi_ v2.2.0 and _PasHiGUI_ v1.2.0. Changes are as follo
   * Fixed CSS errors
 * Made minor changes to read-me file that is included in distributions.
 * Updated various web addresses in documentation.
-* Updated `config-template` comments:
-  * noted fact that the `version` command can't be used in the `config` file
-  * added details of new `line-number-start` command & its parameters
+* Updated `config-template` comments to note that the `version` command can't be used in the `config` file
+* Bumped config files version from 4 to 5.
 
 ## Release 2.1.0 - 2021-09-22
 
@@ -96,6 +95,7 @@ This release includes _PasHi_ v2.1.0 and _PasHiGUI_ v1.1.0. Changes are as follo
   * noted fact that the `help` command can no longer be used in the `config` file
   * added details of new `viewport` and `edge-compatibility` commands
   * noted new command parameters
+* Bumped config files version from 3 to 4.
 * Commented all v1 CSS classes as deprecated in `.css` files.
 
 ## Release 2.0.0 - 2016-09-22

--- a/Config/config-template
+++ b/Config/config-template
@@ -217,10 +217,13 @@
 #     where <param> is a number in range 1..6
 #   line-number-padding <param>
 #     where <param> is one of "space", "zero", "dot" or "dash"
+# line-number-start <param>
+#     where <param> is a number in range 1...9999
 # Defaults:
 #   line-numbering off
 #   line-number-width 3
 #   line-number-padding space
+#   line-number-start 1
 
 
 # --- Line styling ---


### PR DESCRIPTION
Restore line-number-start command details in config-template file.

Correct change log re line-number-start details _not_ appearing in config-template in release 2.2.0.

Add details of config files version updates in change log.